### PR TITLE
Add sudoku killer functions

### DIFF
--- a/PostCode/CombMatrixP.mac
+++ b/PostCode/CombMatrixP.mac
@@ -2,14 +2,17 @@
 /* Tests whether an object is of the form of a Combined Matrix of the size specified */
 
 CombMatrixP(Object,Size):=block([N:Size,n:sqrt(Size),Result:true],
-    if matrixp(Object)=false then return(false),
+    if matrixp(Object)=false then return(false),
+
     if matrix_size(Object)#[N,N] then return(false),
-    for i:1 thru n while Result do (
+    
+for i:1 thru n while Result do (
+
         for j:1 thru n while Result do block([Value:Object[i,j]],
-            if not integerp(Value) then Result:false
+            if not integerp(Value) then Result:false
+
             else if Value<0 or Value>N then Result:false
         )
     ),
     Result
 );
-

--- a/PostCode/ConvertCM2SM.mac
+++ b/PostCode/ConvertCM2SM.mac
@@ -1,6 +1,8 @@
 
-/* Converts a Combined Matrix into a Sudoku Matrix */
-
+/* Converts a Combined Matrix into a Sudoku Matrix */
+
+
+
 ConvertCM2SM(CombMatrix):=block([N:length(CombMatrix[1]),n:sqrt(N),Positions],
     load(SudokuMatrixGen),
     load(GetPositions),
@@ -11,4 +13,3 @@ ConvertCM2SM(CombMatrix):=block([N:length(CombMatrix[1]),n:sqrt(N),Positions],
     ),
     SudokuMatrix
 );
-

--- a/PostCode/ConvertCM2SMOther.mac
+++ b/PostCode/ConvertCM2SMOther.mac
@@ -1,9 +1,12 @@
 
-/* Converts a Combined Matrix into a Sudoku Matrix */
-
+/* Converts a Combined Matrix into a Sudoku Matrix */
+
+
+
 ConvertCM2SM(CombMatrix):=block([N,n,TempMatrix],
     N:matrix_size(CombMatrix)[1],
-    n:sqrt(N),
+    n:sqrt(N),
+
     SudokuMatrix:zeromatrix(n,n),
     for i:1 thru n do (
         for j:1 thru n do (
@@ -17,4 +20,3 @@ ConvertCM2SM(CombMatrix):=block([N,n,TempMatrix],
 Test:matrix([1,2,3,4],[3,4,1,2],[2,3,4,1],[4,1,2,3]);
 
 submatrix(3,4,Test,3,4);
-

--- a/PostCode/ConvertToCNF.mac
+++ b/PostCode/ConvertToCNF.mac
@@ -1,5 +1,6 @@
 
-/* Converts a Combined Matrix into a CNF format */
+
+/* Converts a Combined Matrix into a CNF format */
 
 ConvertToCNF(InMatrix,IsSolution):=block([N:length(InMatrix[1]),CNF,ListCNF,Mult,Clause],
     CNF:"",
@@ -27,4 +28,3 @@ ConvertToCNF(InMatrix,IsSolution):=block([N:length(InMatrix[1]),CNF,ListCNF,Mult
     ),
     Output
 );
-

--- a/PostCode/GenSolution.mac
+++ b/PostCode/GenSolution.mac
@@ -1,7 +1,11 @@
 
-/* Generate a solution of specified size */
-
-GenSolution(Size):=block
+/* Generate a solution of specified size */
+
+
+
+GenSolution(Size):=block
+
+
 ([N:Size,SudokuMatrix,CombMatrix,AllPossValues,NotPossValues,BackTrack:0,Count:1,Positions,Possibles,NotPossibles,RandomValue],
     load(SudokuMatrixGen),
     load(CombMatrixGen),
@@ -11,35 +15,63 @@ GenSolution(Size):=block
     load(SetValue),
     load(GetValue),
 
-    SudokuMatrix:SudokuMatrixGen(N),
-    CombMatrix:CombMatrixGen(N),
-    AllPossValues:GenAllPossValuesList(N),
-    NotPossValues:GenNotPossValuesList(N),
-    Backtrack:0,
-    
-    while Count<=(N^2) do (
-        Possibles:AllPossValues,
-        NotPossibles:NotPossibles(Count,SudokuMatrix,CombMatrix,NotPossValues[Count]),
-
-        if ((length(NotPossibles))=Size) then (
-            Backtrack:Backtrack+1,
-            NotPossValuesList[Count]:[],
-            SetValue(SudokuMatrix,SudokuMatrix,Count,0),
-            SetValue(CombMatrix,CombMatrix,Count,0),
-            Count:Count-1,
-            NotPossValuesList[Count]:append(NotPossValuesList[Count],[GetValue(SudokuMatrix,SudokuMatrix,Count)])
-        )
-
-        else(
-            for i:1 thru length(NotPossibles) do (
-                Possibles: delete(NotPossibles[i], Possibles)
-            ),
-            RandomValue: Possibles[1+random(length(Possibles))],
-            SetValue(SudokuMatrix,SudokuMatrix,Count,RandomValue),
-            SetValue(CombMatrix,CombMatrix,Count,RandomValue),
-            Count:Count+1
-        )
-    ),
-    SudokuMatrix
-);
+    SudokuMatrix:SudokuMatrixGen(N),
 
+    CombMatrix:CombMatrixGen(N),
+
+    AllPossValues:GenAllPossValuesList(N),
+
+    NotPossValues:GenNotPossValuesList(N),
+
+    Backtrack:0,
+
+    
+
+    while Count<=(N^2) do (
+
+        Possibles:AllPossValues,
+
+        NotPossibles:NotPossibles(Count,SudokuMatrix,CombMatrix,NotPossValues[Count]),
+
+
+
+        if ((length(NotPossibles))=Size) then (
+
+            Backtrack:Backtrack+1,
+
+            NotPossValuesList[Count]:[],
+
+            SetValue(SudokuMatrix,SudokuMatrix,Count,0),
+
+            SetValue(CombMatrix,CombMatrix,Count,0),
+
+            Count:Count-1,
+            NotPossValuesList[Count]:append(NotPossValuesList[Count],[GetValue(SudokuMatrix,SudokuMatrix,Count)])
+
+        )
+
+
+
+        else(
+
+            for i:1 thru length(NotPossibles) do (
+
+                Possibles: delete(NotPossibles[i], Possibles)
+
+            ),
+
+            RandomValue: Possibles[1+random(length(Possibles))],
+
+            SetValue(SudokuMatrix,SudokuMatrix,Count,RandomValue),
+
+            SetValue(CombMatrix,CombMatrix,Count,RandomValue),
+
+            Count:Count+1
+
+        )
+
+    ),
+
+    SudokuMatrix
+
+);

--- a/PostCode/GenSolutionOutput1.mac
+++ b/PostCode/GenSolutionOutput1.mac
@@ -1,36 +1,67 @@
 
-
+
+
 /* Generate a solution of specified size */
 
-GenSolutionOutput1(Size):=block([N:Size,SudokuMatrix,CombMatrix,AllPossValues,NotPossValues,BackTrack:0,Count:1,Positions,Possibles,NotPossibles,RandomValue],    load(SudokuMatrixGen),
+
+
+GenSolutionOutput1(Size):=block
+
+([N:Size,SudokuMatrix,CombMatrix,AllPossValues,NotPossValues,BackTrack:0,Count:1,Positions,Possibles,NotPossibles,RandomValue],    load(SudokuMatrixGen),
     load(CombMatrixGen),  
   load(GenAllPossValuesList),    load(GenNotPossValuesList),    load(NotPossibles),    load(SetValue),
-    load(GetValue),    SudokuMatrix:SudokuMatrixGen(N),    CombMatrix:CombMatrixGen(N),
-    AllPossValues:GenAllPossValuesList(N),    NotPossValues:GenNotPossValuesList(N),
-    Backtrack:0,
-       while Count<=(N^2) do ( 
+    load(GetValue),    SudokuMatrix:SudokuMatrixGen(N),
+    CombMatrix:CombMatrixGen(N),
+
+    AllPossValues:GenAllPossValuesList(N),
+    NotPossValues:GenNotPossValuesList(N),
+
+    Backtrack:0,
+
+    
+   while Count<=(N^2) do (
+ 
        Possibles:AllPossValues,
-       NotPossibles:NotPossibles(Count,SudokuMatrix,CombMatrix,NotPossValues[Count]),
-       if ((length(NotPossibles))=Size) then (
-            Backtrack:Backtrack+1, 
+
+       NotPossibles:NotPossibles(Count,SudokuMatrix,CombMatrix,NotPossValues[Count]),
+
+
+       if ((length(NotPossibles))=Size) then (
+
+            Backtrack:Backtrack+1,
+ 
            NotPossValuesList[Count]:[],
-            SetValue(SudokuMatrix,SudokuMatrix,Count,0),
-            SetValue(CombMatrix,CombMatrix,Count,0),
+
+            SetValue(SudokuMatrix,SudokuMatrix,Count,0),
+
+            SetValue(CombMatrix,CombMatrix,Count,0),
+
             Count:Count-1, 
-           NotPossValuesList[Count]:append(NotPossValuesList[Count],[GetValue(SudokuMatrix,SudokuMatrix,Count)]) 
-       )
-        else(
+           NotPossValuesList[Count]:append(NotPossValuesList[Count],[GetValue(SudokuMatrix,SudokuMatrix,Count)])
+ 
+       )
+
+
+        else(
+
             for i:1 thru length(NotPossibles) do (
-                Possibles: delete(NotPossibles[i], Possibles)
-            ), 
-           RandomValue: Possibles[1+random(length(Possibles))], 
-           SetValue(SudokuMatrix,SudokuMatrix,Count,RandomValue), 
-           SetValue(CombMatrix,CombMatrix,Count,RandomValue), 
-           Count:Count+1 
-       )
-    ),
+
+                Possibles: delete(NotPossibles[i], Possibles)
+
+            ),
+ 
+           RandomValue: Possibles[1+random(length(Possibles))],
+ 
+           SetValue(SudokuMatrix,SudokuMatrix,Count,RandomValue),
+ 
+           SetValue(CombMatrix,CombMatrix,Count,RandomValue),
+ 
+           Count:Count+1
+ 
+       )
+
+    ),
+
+
     Output:sconcat(list_matrix_entries(CombMatrix)," ",mattrace(CombMatrix)," ",Backtrack)
-);
-
-
-
+);

--- a/PostCode/GetValue.mac
+++ b/PostCode/GetValue.mac
@@ -2,5 +2,27 @@
 /* Retrieves a value in a position in a matrix */
 
 GetValue(Matrix, Type, Count):=block([Positions,Band,Stack,Row,Column,CMRow,CMColumn],
-    load(GetPositions),    if Type=SudokuMatrix then (        Positions:GetPositions(Count,(length(Matrix[1]))^2),        Band:Positions[1],        Stack:Positions[2],        Row:Positions[3],        Column:Positions[4],        Value:Matrix[Band,Stack][Row,Column]    ),    if Type=CombMatrix then (        Positions:GetPositions(Count,length(Matrix[1])),        CMRow:Positions[5],        CMColumn:Positions[6],        Value:Matrix[CMRow,CMColumn]    ),    Value);
+    load(GetPositions),
+    if Type=SudokuMatrix then (
+        Positions:GetPositions(Count,(length(Matrix[1]))^2),
 
+        Band:Positions[1],
+        Stack:Positions[2],
+        Row:Positions[3],
+        Column:Positions[4],
+        Value:Matrix[Band,Stack][Row,Column]
+
+    ),
+
+    if Type=CombMatrix then (
+        Positions:GetPositions(Count,length(Matrix[1])),
+
+        CMRow:Positions[5],
+        CMColumn:Positions[6],
+        Value:Matrix[CMRow,CMColumn]
+
+    ),
+
+    Value
+
+);

--- a/PostCode/NotPossibles.mac
+++ b/PostCode/NotPossibles.mac
@@ -1,23 +1,63 @@
 
-
-/* For a given matrix and position, creates a list of value which can not be placed in thet cell */
-
-NotPossibles(Count,SudokuMatrix,CombMatrix,ListNotPossValues):=block([Band,Stack,Row,Column,Temp,Positions,N:length(CombMatrix[1]),n:length(SudokuMatrix[1])],
-    load(GetPositions),
-    Positions:GetPositions(Count,N),    Band:Positions[1],    Stack:Positions[2],    Row:Positions[3],    Column:Positions[4],    Temp: row(CombMatrix, (n*(Band-1)+Row)),
-    Temp: Temp[1],
-    NotPossRow: rest(Temp,-(N-(n*(Stack-1))-Column+1)),
-    Temp: col(CombMatrix, (n*(Stack-1)+Column)),
-    Temp: transpose(Temp),
-    Temp: Temp[1],
-    NotPossCol: rest(Temp,-(N-(n*(Band-1))-Row+1)),
-    Temp: row(SudokuMatrix[Band,Stack],1),
-    for i:2 thru n do(
-        TempRow: row(SudokuMatrix[Band,Stack],i),
-        Temp: addcol(Temp, TempRow)    ),
-    TempRow: Temp[1],
-    NotPossBox: rest(TempRow, -(N-(n*(Row-1))-Column+1)),
-    NotPossibles: append(NotPossRow,NotPossCol, NotPossBox, ListNotPossValues),
-    NotPossibles: unique(NotPossibles)
-);
 
+
+
+/* For a given matrix and position, creates a list of value which can not be placed in thet cell */
+
+
+
+
+
+NotPossibles(Count,SudokuMatrix,CombMatrix,ListNotPossValues):=block([Band,Stack,Row,Column,Temp,Positions,N:length(CombMatrix[1]),n:length(SudokuMatrix[1])],
+
+
+    load(GetPositions),
+
+    Positions:GetPositions(Count,N),    Band:Positions[1],    Stack:Positions[2],    Row:Positions[3],    Column:Positions[4],    Temp: row(CombMatrix, (n*(Band-1)+Row)),
+
+
+    Temp: Temp[1],
+
+
+    NotPossRow: rest(Temp,-(N-(n*(Stack-1))-Column+1)),
+
+
+    Temp: col(CombMatrix, (n*(Stack-1)+Column)),
+
+
+    Temp: transpose(Temp),
+
+
+    Temp: Temp[1],
+
+
+    NotPossCol: rest(Temp,-(N-(n*(Band-1))-Row+1)),
+
+
+    Temp: row(SudokuMatrix[Band,Stack],1),
+
+
+    for i:2 thru n do(
+
+
+        TempRow: row(SudokuMatrix[Band,Stack],i),
+
+
+        Temp: addcol(Temp, TempRow)
+    ),
+
+
+    TempRow: Temp[1],
+
+
+    NotPossBox: rest(TempRow, -(N-(n*(Row-1))-Column+1)),
+
+
+
+    NotPossibles: append(NotPossRow,NotPossCol, NotPossBox, ListNotPossValues),
+
+
+    NotPossibles: unique(NotPossibles)
+
+
+);

--- a/PostCode/RemoveAllRandomGivens.mac
+++ b/PostCode/RemoveAllRandomGivens.mac
@@ -1,5 +1,10 @@
 
-/* Removes random values until no more can be removed whilst preserving a unique solution  */RemoveAllRandomGivens(CombMatrix):=block([N:length(CombMatrix[1]),ListOfRemCells,CNFSolM],    load(LoadRemoving),
+
+/* Removes random values until no more can be removed whilst preserving a unique solution  */
+
+
+
+RemoveAllRandomGivens(CombMatrix):=block([N:length(CombMatrix[1]),ListOfRemCells,CNFSolM],    load(LoadRemoving),
     LoadRemoving(),
     SeedRandom(),    ListOfRemCells:GenListRemCells(CombMatrix),    CNFSolM:ConvertToCNF(CombMatrix,true),
 
@@ -7,4 +12,3 @@
         RemoveOneRandomGiven(CombMatrix,CNFSolM,ListOfRemCells)
     )
 );
-

--- a/PostCode/RemoveOneRandomGiven.mac
+++ b/PostCode/RemoveOneRandomGiven.mac
@@ -1,8 +1,16 @@
 
-/* Remove one value selected using the PRNG */
-
-RemoveOneRandomGiven(CombMatrix,CNFSolM,ListOfRemCells):=block([],
-    ListValuePos:1+random(length(ListOfRemCells)),    ValuePos:ListOfRemCells[ListValuePos][1],    ListOfRemCells:delete(ListOfRemCells[ListValuePos],ListOfRemCells),    RemovedValue:GetValue(CombMatrix,CombMatrix,ValuePos),    SetValue(CombMatrix,CombMatrix,ValuePos,0),
-
-    Satisfiable:TestSatisfiable(CombMatrix,CNFSolM),    if Satisfiable="s SATISFIABLE" then (        SetValue(CombMatrix,CombMatrix,ValuePos,RemovedValue)    ),    Satisfiable:"");
-
+ /* Remove one value selected using the PRNG */
+	
+	RemoveOneRandomGiven(CombMatrix,CNFSolM,ListOfRemCells):=block(
+	    [],
+	    ListValuePos:1+random(length(ListOfRemCells)),
+	    ValuePos:ListOfRemCells[ListValuePos][1],
+	    ListOfRemCells:delete(ListOfRemCells[ListValuePos],ListOfRemCells),
+	    RemovedValue:GetValue(CombMatrix,CombMatrix,ValuePos),
+	    SetValue(CombMatrix,CombMatrix,ValuePos,0),
+	    Satisfiable:TestSatisfiable(CombMatrix,CNFSolM),
+	    if Satisfiable="s SATISFIABLE" then (
+	        SetValue(CombMatrix,CombMatrix,ValuePos,RemovedValue)
+	    ),
+	    Satisfiable:""
+	)$

--- a/PostCode/SMSolutionP.mac
+++ b/PostCode/SMSolutionP.mac
@@ -1,27 +1,48 @@
 
-
-/* Tests whether a Sudoku Matrix is a solution */
-
-SMSolutionP(SudokuMatrix):=block([n:length(SudokuMatrix[1]),N:n^2,Result:true,BaseList,TranBaseList,TempList,CombMatrix],
-    BaseList:makelist(x,x,N),
-    TranBaseList:transpose(BaseList),
-    for i:1 thru n while Result do (
-        for j:1 thru n while Result do (
-            TempList:sort(list_matrix_entries(SudokuMatrix[i,j])),
-            if TempList#BaseList then Result:false
-        )
-    ),
-    if Result=false then return(false),
-    load(ConvertSMToCM),
-    CombMatrix:ConvertSMToCM(SudokuMatrix),
-    for i:1 thru N while Result do (
-        TempList:sort(row(CombMatrix,i)),
-        if TempList#BaseList then Result:false
-    ),
-    for i:1 thru N while Result do (
-        TempList:sort(column(CombMatrix,i)),
-        if TempList#TranBaseList then Result:false
+
+
+/* Tests whether a Sudoku Matrix is a solution */
+
+
+
+SMSolutionP(SudokuMatrix):=block([n:length(SudokuMatrix[1]),N:n^2,Result:true,BaseList,TranBaseList,TempList,CombMatrix],
+
+    BaseList:makelist(x,x,N),
+
+    TranBaseList:transpose(BaseList),
+
+    for i:1 thru n while Result do (
+
+        for j:1 thru n while Result do (
+
+            TempList:sort(list_matrix_entries(SudokuMatrix[i,j])),
+
+            if TempList#BaseList then Result:false
+
+        )
+
+    ),
+
+    if Result=false then return(false),
+
+    load(ConvertSMToCM),
+
+    CombMatrix:ConvertSMToCM(SudokuMatrix),
+
+    for i:1 thru N while Result do (
+
+        TempList:sort(row(CombMatrix,i)),
+
+        if TempList#BaseList then Result:false
+
+    ),
+
+    for i:1 thru N while Result do (
+
+        TempList:sort(column(CombMatrix,i)),
+
+        if TempList#TranBaseList then Result:false
+
     ),
     Result
 );
-

--- a/PostCode/SetValue.mac
+++ b/PostCode/SetValue.mac
@@ -1,22 +1,28 @@
 
-
+
+
 /* Assigns a value to a position in a matrix */
 
 SetValue(Matrix, Type, Count, Value):=block([Positions,Band,Stack,Row,Column,CMRow,CMColumn],
     load(GetPositions),
     if Type=SudokuMatrix then (
         Positions:GetPositions(Count,(length(Matrix[1]))^2),
-        Band:Positions[1],
-        Stack:Positions[2],
-        Row:Positions[3],
-        Column:Positions[4],
+        Band:Positions[1],
+
+        Stack:Positions[2],
+
+        Row:Positions[3],
+
+        Column:Positions[4],
+
         Matrix[Band,Stack][Row,Column]:Value
     ),
     if Type=CombMatrix then (
         Positions:GetPositions(Count,length(Matrix[1])),
-        CMRow:Positions[5],
-        CMColumn:Positions[6],
+        CMRow:Positions[5],
+
+        CMColumn:Positions[6],
+
         Matrix[CMRow,CMColumn]:Value
     )
 );
-

--- a/PostCode/SudokuMatrixP.mac
+++ b/PostCode/SudokuMatrixP.mac
@@ -1,23 +1,40 @@
 
-/* Tests whether an object is of the form of a Sudoku Matrix of the size specified */
-
-SudokuMatrixP(Object,Size):=block([N:Size,n:sqrt(Size),Result:true],
-    if matrixp(Object)=false then return(false),
-    if matrix_size(Object)#[n,n] then return(false),
-    for i:1 thru n while Result do (
-        for j:1 thru n while Result do (
-            if matrixp(Object[i,j])=false then Result:false
-            else if matrix_size(Object[i,j])#[n,n] then Return:false
-            else (
-                for k:1 thru n while Result do(
-                    for l:1 thru n while Result do block([Value:Object[i,j][k,l]],
-                        if not integerp(Value) then Result:false
-                        else if Value<0 or Value>N then Result:false
-                    )
-                )
-            )
-        )
+/* Tests whether an object is of the form of a Sudoku Matrix of the size specified */
+
+
+
+SudokuMatrixP(Object,Size):=block([N:Size,n:sqrt(Size),Result:true],
+
+    if matrixp(Object)=false then return(false),
+
+    if matrix_size(Object)#[n,n] then return(false),
+
+    for i:1 thru n while Result do (
+
+        for j:1 thru n while Result do (
+
+            if matrixp(Object[i,j])=false then Result:false
+
+            else if matrix_size(Object[i,j])#[n,n] then Return:false
+
+            else (
+
+                for k:1 thru n while Result do(
+
+                    for l:1 thru n while Result do block([Value:Object[i,j][k,l]],
+
+                        if not integerp(Value) then Result:false
+
+                        else if Value<0 or Value>N then Result:false
+
+                    )
+
+                )
+
+            )
+
+        )
+
     ),
     Result
 );
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sudoku implementation in Maxima.
 
-This code was initally left in GitHub by the user Cheesily.
+This code was initally left in GitHub by the user Cheesily since 2014.
 
 Can be corrected and expanded to make it fully operative.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Sudoku implementation in Maxima.
+
+This code was initally left in GitHub by the user Cheesily.
+
+Can be corrected and expanded to make it fully operative.

--- a/SudokuKillerFunctions.wxm
+++ b/SudokuKillerFunctions.wxm
@@ -1,0 +1,243 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 22.04.0 ] */
+/* [wxMaxima: input   start ] */
+check_killer(upto,boxes):=sublist(
+    listify(integer_partitions(upto,boxes)),
+    lambda([x],is(cardinality(setify(x))=boxes and every(lambda([y],is(y<10)),setify(x)) and not member(0,x)))
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+La condición es que todas las jaulas estén en una misma fila, columna o cuadrícula de nueve casillas
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+check_many(list):=block(
+    list_evaluations:map(lambda([x],apply(check_killer,x)),list),
+    cartesian:apply(cartesian_product_list,list_evaluations),
+    joint_sum:apply("+",map(lambda([x],x[2]),list)),
+    sublist(cartesian,lambda([x],is(cardinality(apply(union,listify(fullsetify(x))))=joint_sum)))
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+including(list,set):=sublist(
+    apply(check_killer,list),
+    lambda([x],subsetp(set,setify(x)))
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+excluding(list,set):=sublist(
+    apply(check_killer,list),
+    lambda([x],disjointp(set,setify(x)))
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+La siguiente es la forma de generar el conjunto de los dígitos sin 0.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+makeset(j,[j],map("[",makelist(i,i,9)))$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+complement(list):=map(
+    lambda([x],setdifference({1,2,3,4,5,6,7,8,9},apply(union,listify(fullsetify(x))))),
+    list
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Usualmente hacía una conjunto con la unión de aquellos que contenían algo que se tenía que descargar,
+pero he visto la necesidad de mejor hacer varias llamadas centradas en un único conjunto.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+filtered_by_complement(list,set):=sublist(
+    list,
+    lambda([x],not subsetp(setdifference({1,2,3,4,5,6,7,8,9},apply(union,listify(fullsetify(x)))),set))
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+filtered_other_way(list,set):=sublist(
+    list,
+    lambda([x],subsetp(setdifference({1,2,3,4,5,6,7,8,9},apply(union,listify(fullsetify(x)))),set))
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Intenta hallar un número común a todas las posibilidades.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+common(list):=block(
+    result:[],
+    len:length(first(list)),
+    for i from 1 thru len do (
+        arg_intersec:map(lambda([x],setify(x[i])),list),
+        result:endcons(arg_intersec,result)
+    ),
+    map(lambda([x],apply(intersection,x)),result)
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Sería bueno evaluar si la filtración se debe hacer estratificadamente.
+Se debería evaluar la viabilidad de una función de inclusión y exclusión simultaneas.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+in_ex(cage,set_in,set_ex):=apply(
+    intersection,
+    [fullsetify(including(cage,set_in)),fullsetify(excluding(cage,set_ex))]
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Hace lo que hace complement, pero para la salida de funciones como including o excluding.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+post_inex(list_inex):=apply(
+    intersection,
+    listify(fullsetify(list_inex))
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Esta función hace una unión de aquellas jaulas en las cuales no se ha alcanzado a determinar cual de los integrates de list_sets sí está en la jaula.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+or_including(cage,list_sets):=unique(
+    apply(append,
+        map(
+            lambda([x],including(cage,x)),
+            list_sets
+        )
+    )
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+/* stratified(list,list_sets):=block(
+    list_applied:check_many(list),
+    complem:complement(list_applied),
+    sample:flatten(map(lambda([y],unique(sublist(complem,lambda([x],subsetp(y,x))))),list_sets)),
+    for i in sample do list_applied:filtered_by_complement(list_applied,i),
+    list_applied
+)$ */
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+stratified(list,list_sets):=block(
+    list_applied:check_many(list),
+    complem:complement(list_applied),
+    sample:flatten(map(lambda([y],unique(sublist(complem,lambda([x],subsetp(y,x))))),list_sets)),
+    for i in sample do list_applied:filtered_by_complement(list_applied,i),
+    sample:list_applied,
+    complems:map(
+        lambda([x],setdifference({1,2,3,4,5,6,7,8,9},apply(union,listify(fullsetify(x))))),
+        sample
+    ),
+    table_form(apply(join,[complems,sample]))
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+He experimentado un problema con la priomera implementación de esta función.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+stratified_other_way(list,list_sets):=block(
+    list_applied:check_many(list),
+    complem:complement(list_applied),
+    sample:flatten(map(lambda([y],unique(sublist(complem,lambda([x],subsetp(y,x))))),list_sets)),
+    for i in sample do list_applied:filtered_other_way(list_applied,i),
+    list_applied
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+stratified_out(list,set):=block(
+    list_evaluations:map(lambda([x],apply(check_killer,x)),list),
+    cartesian:apply(cartesian_product_list,list_evaluations),
+    joint_sum:apply("+",map(lambda([x],x[2]),list)),
+    sample:sublist(cartesian,lambda([x],is(cardinality(apply(union,listify(fullsetify(x))))=joint_sum))),
+    complems:map(
+        lambda([x],setdifference({1,2,3,4,5,6,7,8,9},apply(union,listify(fullsetify(x))))),
+        sample
+    ),
+    sublist(complems,lambda([x],subsetp(set,x)))
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Esta función tiene la funcionalidad de aplicar primero check_many, después complement
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+check_complem(list):=block(
+    list_evaluations:map(lambda([x],apply(check_killer,x)),list),
+    cartesian:apply(cartesian_product_list,list_evaluations),
+    joint_sum:apply("+",map(lambda([x],x[2]),list)),
+    sample:sublist(cartesian,lambda([x],is(cardinality(apply(union,listify(fullsetify(x))))=joint_sum))),
+    complems:map(
+        lambda([x],setdifference({1,2,3,4,5,6,7,8,9},apply(union,listify(fullsetify(x))))),
+        sample
+    ),
+    table_form(apply(join,[complems,sample]))
+)$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: comment start ]
+Si se tiene la alineación o disposición adecuada de jaulas se pueden sumar todas y se les resta 45.
+Me parece que algo bueno para los stratified alternativos será generar un lista de conjuntos relacionada con el complemento. Por ejemplo, si es un caso en el cual se quiere que esté incluido el 2 se debe usar un stratified en el cual se excluya todo lo demás.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: comment start ]
+Puede dar como respuesta una lista vacía. Lo que es necesario para que no sea vacía son valores adicionales en set.
+   [wxMaxima: comment end   ] */
+
+
+/* [wxMaxima: input   start ] */
+stratified_altern(list,set):=block(
+    list_sets:listify(fullsetify(map("[",listify(setdifference({1,2,3,4,5,6,7,8,9},set))))),
+    stratified(list,list_sets)
+)$
+/* [wxMaxima: input   end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 22.04.0"$


### PR DESCRIPTION
Title: Add Sudoku Killer Functions
Description:
This pull request introduces SudokuKillerFunctions.wxm, a new Maxima batch file containing a comprehensive set of functions specifically designed for Killer Sudoku puzzle operations.

Key Features Added:
check_killer(upto, boxes): Generates valid integer partitions for Killer Sudoku cages, ensuring no zeros and unique digits under 10.
check_many(list): Evaluates multiple cage configurations and finds valid combinations where the total sum matches the expected cardinality.
including(list, set) and excluding(list, set): Filter cage possibilities based on whether they must include or exclude specific digit sets.
complement(list): Computes complementary digit sets for each cage configuration.
filtered_by_complement() and filtered_other_way(): Advanced filtering functions for cage possibilities based on complementary sets.
common(list): Identifies digits that appear in all possible configurations for a given position.
Purpose:
These functions extend the Sudoku_Maxima project to support Killer Sudoku (also known as Sum Sudoku) puzzles, where cells within cages must sum to specific values. The implementation provides tools for generating, validating, and solving Killer Sudoku constraints within the Maxima computer algebra system.

Files Changed:
Added: SudokuKillerFunctions.wxm - New file with Killer Sudoku utility functions
Testing:
The functions are designed to work with the existing Sudoku_Maxima framework and can be loaded alongside other Maxima batch files for generating and solving Killer Sudoku puzzles.

This addition enhances the project's capabilities for advanced Sudoku variants while maintaining compatibility with the existing codebase.