### PR TITLE
Add precode test

### DIFF
--- a/PostCode/CombMatrixP.mac
+++ b/PostCode/CombMatrixP.mac
@@ -2,14 +2,17 @@
 /* Tests whether an object is of the form of a Combined Matrix of the size specified */
 
 CombMatrixP(Object,Size):=block([N:Size,n:sqrt(Size),Result:true],
-    if matrixp(Object)=false then return(false),
+    if matrixp(Object)=false then return(false),
+
     if matrix_size(Object)#[N,N] then return(false),
-    for i:1 thru n while Result do (
+    
+for i:1 thru n while Result do (
+
         for j:1 thru n while Result do block([Value:Object[i,j]],
-            if not integerp(Value) then Result:false
+            if not integerp(Value) then Result:false
+
             else if Value<0 or Value>N then Result:false
         )
     ),
     Result
 );
-

--- a/PostCode/ConvertCM2SM.mac
+++ b/PostCode/ConvertCM2SM.mac
@@ -1,6 +1,8 @@
 
-/* Converts a Combined Matrix into a Sudoku Matrix */
-
+/* Converts a Combined Matrix into a Sudoku Matrix */
+
+
+
 ConvertCM2SM(CombMatrix):=block([N:length(CombMatrix[1]),n:sqrt(N),Positions],
     load(SudokuMatrixGen),
     load(GetPositions),
@@ -11,4 +13,3 @@ ConvertCM2SM(CombMatrix):=block([N:length(CombMatrix[1]),n:sqrt(N),Positions],
     ),
     SudokuMatrix
 );
-

--- a/PostCode/ConvertCM2SMOther.mac
+++ b/PostCode/ConvertCM2SMOther.mac
@@ -1,9 +1,12 @@
 
-/* Converts a Combined Matrix into a Sudoku Matrix */
-
+/* Converts a Combined Matrix into a Sudoku Matrix */
+
+
+
 ConvertCM2SM(CombMatrix):=block([N,n,TempMatrix],
     N:matrix_size(CombMatrix)[1],
-    n:sqrt(N),
+    n:sqrt(N),
+
     SudokuMatrix:zeromatrix(n,n),
     for i:1 thru n do (
         for j:1 thru n do (
@@ -17,4 +20,3 @@ ConvertCM2SM(CombMatrix):=block([N,n,TempMatrix],
 Test:matrix([1,2,3,4],[3,4,1,2],[2,3,4,1],[4,1,2,3]);
 
 submatrix(3,4,Test,3,4);
-

--- a/PostCode/ConvertToCNF.mac
+++ b/PostCode/ConvertToCNF.mac
@@ -1,5 +1,6 @@
 
-/* Converts a Combined Matrix into a CNF format */
+
+/* Converts a Combined Matrix into a CNF format */
 
 ConvertToCNF(InMatrix,IsSolution):=block([N:length(InMatrix[1]),CNF,ListCNF,Mult,Clause],
     CNF:"",
@@ -27,4 +28,3 @@ ConvertToCNF(InMatrix,IsSolution):=block([N:length(InMatrix[1]),CNF,ListCNF,Mult
     ),
     Output
 );
-

--- a/PostCode/CoreGen.mac
+++ b/PostCode/CoreGen.mac
@@ -1,0 +1,137 @@
+/* Core Generation and Matrix Operations */
+
+/* Takes a value which represents a square, and returns the band, stack, row within the band and the column within the stack */
+
+GetPositions(Value,Size):=block([Position:Value,N:Size,n:sqrt(Size),Band,Stack,Row,Column,CMRow,CMColumn],
+    Band:1+quotient(Value-1,n^3),
+    Stack:1+quotient(mod(Value-1,n^3),N),
+    Row:1+quotient(mod(Value-1,N),n),
+    Column:1+mod(Value-1,n),
+    CMRow:n*(Band-1)+Row,
+    CMColumn:n*(Stack-1)+Column,
+    ListOfPositions:[Band,Stack,Row,Column,CMRow,CMColumn]
+);
+
+/* Sudoku Matrix Generator */
+
+SudokuMatrixGen(N):= block([n:sqrt(N)],
+    SudokuMatrix : zeromatrix(n,n),
+    
+for i:1 thru n do (
+        
+for j:1 thru n do (
+            SudokuMatrix[i,j]:zeromatrix(n,n)
+        )
+    ),
+    SudokuMatrix
+);
+
+/* Combined Matrix Generator */
+
+CombMatrixGen(N):=zeromatrix(N,N);
+
+/* Generates a list of all values in the Sudoku solution for the specified size */
+
+GenAllPossValuesList(Size):=(
+    makelist(i+1,i,0,Size-1)
+);
+
+/* Generates a list used to store information of which values cannot be placed in which positions at that time */
+
+GenNotPossValuesList(Size):=(
+    NotPossValuesList:makelist(),
+    for i from 1 thru (Size^2) do(
+        TempList:[[]],
+        NotPossValuesList:append(NotPossValuesList,TempList)
+    ),
+    NotPossValuesList
+);
+
+/* For a given matrix and position, creates a list of value which can not be placed in that cell */
+
+NotPossibles(Count,SudokuMatrix,CombMatrix,ListNotPossValues):=block([Band,Stack,Row,Column,Temp,Positions,N:length(CombMatrix[1]),n:length(SudokuMatrix[1])],
+
+    Positions:GetPositions(Count,N),    Band:Positions[1],    Stack:Positions[2],    Row:Positions[3],    Column:Positions[4],    Temp: row(CombMatrix, (n*(Band-1)+Row)),
+
+    Temp: args(Temp)[1],
+
+    NotPossRow: rest(Temp,-(N-(n*(Stack-1))-Column+1)),
+
+    Temp: col(CombMatrix, (n*(Stack-1)+Column)),
+
+    Temp: transpose(Temp),
+
+    Temp: args(Temp)[1],
+
+    NotPossCol: rest(Temp,-(N-(n*(Band-1))-Row+1)),
+
+    Temp: row(SudokuMatrix[Band,Stack],1),
+
+    for i:2 thru n do(
+
+        TempRow: row(SudokuMatrix[Band,Stack],i),
+
+        Temp: addcol(Temp, TempRow)
+    ),
+
+    TempRow: args(Temp)[1],
+
+    NotPossBox: rest(TempRow, -(N-(n*(Row-1))-Column+1)),
+
+    NotPossibles: append(NotPossRow,NotPossCol, NotPossBox, ListNotPossValues),
+
+    NotPossibles: unique(NotPossibles)
+
+);
+
+/* Assigns a value to a position in a matrix */
+
+SetValue(Matrix, Type, Count, Value):=block([Positions,Band,Stack,Row,Column,CMRow,CMColumn],
+    if Type=SudokuMatrix then (
+        Positions:GetPositions(Count,(length(Matrix[1]))^2),
+        Band:Positions[1],
+
+        Stack:Positions[2],
+
+        Row:Positions[3],
+
+        Column:Positions[4],
+
+        Matrix[Band,Stack][Row,Column]:Value
+    ),
+    if Type=CombMatrix then (
+        Positions:GetPositions(Count,length(Matrix[1])),
+        CMRow:Positions[5],
+
+        CMColumn:Positions[6],
+
+        Matrix[CMRow,CMColumn]:Value
+    )
+);
+
+/* Retrieves a value in a position in a matrix */
+
+GetValue(Matrix, Type, Count):=block([Positions,Band,Stack,Row,Column,CMRow,CMColumn],
+    if Type=SudokuMatrix then (
+        Positions:GetPositions(Count,(length(Matrix[1]))^2),
+
+        Band:Positions[1],
+        Stack:Positions[2],
+        Row:Positions[3],
+        Column:Positions[4],
+        Value:Matrix[Band,Stack][Row,Column]
+
+    ),
+
+    if Type=CombMatrix then (
+        Positions:GetPositions(Count,length(Matrix[1])),
+
+        CMRow:Positions[5],
+        CMColumn:Positions[6],
+        Value:Matrix[CMRow,CMColumn]
+
+    ),
+
+    Value
+
+);

--- a/PostCode/GenSolution.mac
+++ b/PostCode/GenSolution.mac
@@ -1,7 +1,11 @@
 
-/* Generate a solution of specified size */
-
-GenSolution(Size):=block
+/* Generate a solution of specified size */
+
+
+
+GenSolution(Size):=block
+
+
 ([N:Size,SudokuMatrix,CombMatrix,AllPossValues,NotPossValues,BackTrack:0,Count:1,Positions,Possibles,NotPossibles,RandomValue],
     load(SudokuMatrixGen),
     load(CombMatrixGen),
@@ -11,35 +15,63 @@ GenSolution(Size):=block
     load(SetValue),
     load(GetValue),
 
-    SudokuMatrix:SudokuMatrixGen(N),
-    CombMatrix:CombMatrixGen(N),
-    AllPossValues:GenAllPossValuesList(N),
-    NotPossValues:GenNotPossValuesList(N),
-    Backtrack:0,
-    
-    while Count<=(N^2) do (
-        Possibles:AllPossValues,
-        NotPossibles:NotPossibles(Count,SudokuMatrix,CombMatrix,NotPossValues[Count]),
-
-        if ((length(NotPossibles))=Size) then (
-            Backtrack:Backtrack+1,
-            NotPossValuesList[Count]:[],
-            SetValue(SudokuMatrix,SudokuMatrix,Count,0),
-            SetValue(CombMatrix,CombMatrix,Count,0),
-            Count:Count-1,
-            NotPossValuesList[Count]:append(NotPossValuesList[Count],[GetValue(SudokuMatrix,SudokuMatrix,Count)])
-        )
-
-        else(
-            for i:1 thru length(NotPossibles) do (
-                Possibles: delete(NotPossibles[i], Possibles)
-            ),
-            RandomValue: Possibles[1+random(length(Possibles))],
-            SetValue(SudokuMatrix,SudokuMatrix,Count,RandomValue),
-            SetValue(CombMatrix,CombMatrix,Count,RandomValue),
-            Count:Count+1
-        )
-    ),
-    SudokuMatrix
-);
+    SudokuMatrix:SudokuMatrixGen(N),
 
+    CombMatrix:CombMatrixGen(N),
+
+    AllPossValues:GenAllPossValuesList(N),
+
+    NotPossValues:GenNotPossValuesList(N),
+
+    Backtrack:0,
+
+    
+
+    while Count<=(N^2) do (
+
+        Possibles:AllPossValues,
+
+        NotPossibles:NotPossibles(Count,SudokuMatrix,CombMatrix,NotPossValues[Count]),
+
+
+
+        if ((length(NotPossibles))=Size) then (
+
+            Backtrack:Backtrack+1,
+
+            NotPossValuesList[Count]:[],
+
+            SetValue(SudokuMatrix,SudokuMatrix,Count,0),
+
+            SetValue(CombMatrix,CombMatrix,Count,0),
+
+            Count:Count-1,
+            NotPossValuesList[Count]:append(NotPossValuesList[Count],[GetValue(SudokuMatrix,SudokuMatrix,Count)])
+
+        )
+
+
+
+        else(
+
+            for i:1 thru length(NotPossibles) do (
+
+                Possibles: delete(NotPossibles[i], Possibles)
+
+            ),
+
+            RandomValue: Possibles[1+random(length(Possibles))],
+
+            SetValue(SudokuMatrix,SudokuMatrix,Count,RandomValue),
+
+            SetValue(CombMatrix,CombMatrix,Count,RandomValue),
+
+            Count:Count+1
+
+        )
+
+    ),
+
+    SudokuMatrix
+
+);

--- a/PostCode/GenSolution.mac
+++ b/PostCode/GenSolution.mac
@@ -1,19 +1,13 @@
 
 /* Generate a solution of specified size */
 
-
+file_search_maxima: append (file_search_maxima,["C:/Users/Usuario/Sudoku_Maxima", "C:/Users/Usuario/Sudoku_Maxima/PostCode"])$
 
 GenSolution(Size):=block
 
 
 ([N:Size,SudokuMatrix,CombMatrix,AllPossValues,NotPossValues,BackTrack:0,Count:1,Positions,Possibles,NotPossibles,RandomValue],
-    load(SudokuMatrixGen),
-    load(CombMatrixGen),
-    load(GenAllPossValuesList),
-    load(GenNotPossValuesList),
-    load(NotPossibles),
-    load(SetValue),
-    load(GetValue),
+    load("CoreGen.mac"),
 
     SudokuMatrix:SudokuMatrixGen(N),
 

--- a/PostCode/GenSolutionOutput1.mac
+++ b/PostCode/GenSolutionOutput1.mac
@@ -1,36 +1,67 @@
 
-
+
+
 /* Generate a solution of specified size */
 
-GenSolutionOutput1(Size):=block([N:Size,SudokuMatrix,CombMatrix,AllPossValues,NotPossValues,BackTrack:0,Count:1,Positions,Possibles,NotPossibles,RandomValue],    load(SudokuMatrixGen),
+
+
+GenSolutionOutput1(Size):=block
+
+([N:Size,SudokuMatrix,CombMatrix,AllPossValues,NotPossValues,BackTrack:0,Count:1,Positions,Possibles,NotPossibles,RandomValue],    load(SudokuMatrixGen),
     load(CombMatrixGen),  
   load(GenAllPossValuesList),    load(GenNotPossValuesList),    load(NotPossibles),    load(SetValue),
-    load(GetValue),    SudokuMatrix:SudokuMatrixGen(N),    CombMatrix:CombMatrixGen(N),
-    AllPossValues:GenAllPossValuesList(N),    NotPossValues:GenNotPossValuesList(N),
-    Backtrack:0,
-       while Count<=(N^2) do ( 
+    load(GetValue),    SudokuMatrix:SudokuMatrixGen(N),
+    CombMatrix:CombMatrixGen(N),
+
+    AllPossValues:GenAllPossValuesList(N),
+    NotPossValues:GenNotPossValuesList(N),
+
+    Backtrack:0,
+
+    
+   while Count<=(N^2) do (
+ 
        Possibles:AllPossValues,
-       NotPossibles:NotPossibles(Count,SudokuMatrix,CombMatrix,NotPossValues[Count]),
-       if ((length(NotPossibles))=Size) then (
-            Backtrack:Backtrack+1, 
+
+       NotPossibles:NotPossibles(Count,SudokuMatrix,CombMatrix,NotPossValues[Count]),
+
+
+       if ((length(NotPossibles))=Size) then (
+
+            Backtrack:Backtrack+1,
+ 
            NotPossValuesList[Count]:[],
-            SetValue(SudokuMatrix,SudokuMatrix,Count,0),
-            SetValue(CombMatrix,CombMatrix,Count,0),
+
+            SetValue(SudokuMatrix,SudokuMatrix,Count,0),
+
+            SetValue(CombMatrix,CombMatrix,Count,0),
+
             Count:Count-1, 
-           NotPossValuesList[Count]:append(NotPossValuesList[Count],[GetValue(SudokuMatrix,SudokuMatrix,Count)]) 
-       )
-        else(
+           NotPossValuesList[Count]:append(NotPossValuesList[Count],[GetValue(SudokuMatrix,SudokuMatrix,Count)])
+ 
+       )
+
+
+        else(
+
             for i:1 thru length(NotPossibles) do (
-                Possibles: delete(NotPossibles[i], Possibles)
-            ), 
-           RandomValue: Possibles[1+random(length(Possibles))], 
-           SetValue(SudokuMatrix,SudokuMatrix,Count,RandomValue), 
-           SetValue(CombMatrix,CombMatrix,Count,RandomValue), 
-           Count:Count+1 
-       )
-    ),
+
+                Possibles: delete(NotPossibles[i], Possibles)
+
+            ),
+ 
+           RandomValue: Possibles[1+random(length(Possibles))],
+ 
+           SetValue(SudokuMatrix,SudokuMatrix,Count,RandomValue),
+ 
+           SetValue(CombMatrix,CombMatrix,Count,RandomValue),
+ 
+           Count:Count+1
+ 
+       )
+
+    ),
+
+
     Output:sconcat(list_matrix_entries(CombMatrix)," ",mattrace(CombMatrix)," ",Backtrack)
-);
-
-
-
+);

--- a/PostCode/GetValue.mac
+++ b/PostCode/GetValue.mac
@@ -2,5 +2,27 @@
 /* Retrieves a value in a position in a matrix */
 
 GetValue(Matrix, Type, Count):=block([Positions,Band,Stack,Row,Column,CMRow,CMColumn],
-    load(GetPositions),    if Type=SudokuMatrix then (        Positions:GetPositions(Count,(length(Matrix[1]))^2),        Band:Positions[1],        Stack:Positions[2],        Row:Positions[3],        Column:Positions[4],        Value:Matrix[Band,Stack][Row,Column]    ),    if Type=CombMatrix then (        Positions:GetPositions(Count,length(Matrix[1])),        CMRow:Positions[5],        CMColumn:Positions[6],        Value:Matrix[CMRow,CMColumn]    ),    Value);
+    load(GetPositions),
+    if Type=SudokuMatrix then (
+        Positions:GetPositions(Count,(length(Matrix[1]))^2),
 
+        Band:Positions[1],
+        Stack:Positions[2],
+        Row:Positions[3],
+        Column:Positions[4],
+        Value:Matrix[Band,Stack][Row,Column]
+
+    ),
+
+    if Type=CombMatrix then (
+        Positions:GetPositions(Count,length(Matrix[1])),
+
+        CMRow:Positions[5],
+        CMColumn:Positions[6],
+        Value:Matrix[CMRow,CMColumn]
+
+    ),
+
+    Value
+
+);

--- a/PostCode/GetValue.mac
+++ b/PostCode/GetValue.mac
@@ -2,7 +2,7 @@
 /* Retrieves a value in a position in a matrix */
 
 GetValue(Matrix, Type, Count):=block([Positions,Band,Stack,Row,Column,CMRow,CMColumn],
-    load(GetPositions),
+    load("GetPositions.mac"),
     if Type=SudokuMatrix then (
         Positions:GetPositions(Count,(length(Matrix[1]))^2),
 

--- a/PostCode/LoadPerms.mac
+++ b/PostCode/LoadPerms.mac
@@ -2,11 +2,6 @@
 /* Loads all permutations */
 
 LoadPerms():=(
-    load(SwapBands),
-    load(SwapStacks),
-    load(SwapRows),
-    load(SwapColumns),
-    load(Reflect),
-    load(Rotate)
+    load("Permutations.mac")
 );
 

--- a/PostCode/LoadRemoving.mac
+++ b/PostCode/LoadRemoving.mac
@@ -2,11 +2,10 @@
 /* Loads all files needed to remove givens */
 
 LoadRemoving():=(
-    load(SeedRandom),
-    load(GenListRemCells),
-    load(ConvertToCNF),
-    load(RemoveOneRandomGiven),
-    load(GetValue),
-    load(SetValue),
-    load(TestSatisfiable)
+    load("SeedRandom.mac"),
+    load("GenListRemCells.mac"),
+    load("ConvertToCNF.mac"),
+    load("RemoveOneRandomGiven.mac"),
+    load("CoreGen.mac"),
+    load("TestSatisfiable.mac")
 );

--- a/PostCode/NotPossibles.mac
+++ b/PostCode/NotPossibles.mac
@@ -1,23 +1,63 @@
 
-
-/* For a given matrix and position, creates a list of value which can not be placed in thet cell */
-
-NotPossibles(Count,SudokuMatrix,CombMatrix,ListNotPossValues):=block([Band,Stack,Row,Column,Temp,Positions,N:length(CombMatrix[1]),n:length(SudokuMatrix[1])],
-    load(GetPositions),
-    Positions:GetPositions(Count,N),    Band:Positions[1],    Stack:Positions[2],    Row:Positions[3],    Column:Positions[4],    Temp: row(CombMatrix, (n*(Band-1)+Row)),
-    Temp: Temp[1],
-    NotPossRow: rest(Temp,-(N-(n*(Stack-1))-Column+1)),
-    Temp: col(CombMatrix, (n*(Stack-1)+Column)),
-    Temp: transpose(Temp),
-    Temp: Temp[1],
-    NotPossCol: rest(Temp,-(N-(n*(Band-1))-Row+1)),
-    Temp: row(SudokuMatrix[Band,Stack],1),
-    for i:2 thru n do(
-        TempRow: row(SudokuMatrix[Band,Stack],i),
-        Temp: addcol(Temp, TempRow)    ),
-    TempRow: Temp[1],
-    NotPossBox: rest(TempRow, -(N-(n*(Row-1))-Column+1)),
-    NotPossibles: append(NotPossRow,NotPossCol, NotPossBox, ListNotPossValues),
-    NotPossibles: unique(NotPossibles)
-);
 
+
+
+/* For a given matrix and position, creates a list of value which can not be placed in thet cell */
+
+
+
+
+
+NotPossibles(Count,SudokuMatrix,CombMatrix,ListNotPossValues):=block([Band,Stack,Row,Column,Temp,Positions,N:length(CombMatrix[1]),n:length(SudokuMatrix[1])],
+
+
+    load(GetPositions),
+
+    Positions:GetPositions(Count,N),    Band:Positions[1],    Stack:Positions[2],    Row:Positions[3],    Column:Positions[4],    Temp: row(CombMatrix, (n*(Band-1)+Row)),
+
+
+    Temp: Temp[1],
+
+
+    NotPossRow: rest(Temp,-(N-(n*(Stack-1))-Column+1)),
+
+
+    Temp: col(CombMatrix, (n*(Stack-1)+Column)),
+
+
+    Temp: transpose(Temp),
+
+
+    Temp: Temp[1],
+
+
+    NotPossCol: rest(Temp,-(N-(n*(Band-1))-Row+1)),
+
+
+    Temp: row(SudokuMatrix[Band,Stack],1),
+
+
+    for i:2 thru n do(
+
+
+        TempRow: row(SudokuMatrix[Band,Stack],i),
+
+
+        Temp: addcol(Temp, TempRow)
+    ),
+
+
+    TempRow: Temp[1],
+
+
+    NotPossBox: rest(TempRow, -(N-(n*(Row-1))-Column+1)),
+
+
+
+    NotPossibles: append(NotPossRow,NotPossCol, NotPossBox, ListNotPossValues),
+
+
+    NotPossibles: unique(NotPossibles)
+
+
+);

--- a/PostCode/NotPossibles.mac
+++ b/PostCode/NotPossibles.mac
@@ -11,12 +11,12 @@
 NotPossibles(Count,SudokuMatrix,CombMatrix,ListNotPossValues):=block([Band,Stack,Row,Column,Temp,Positions,N:length(CombMatrix[1]),n:length(SudokuMatrix[1])],
 
 
-    load(GetPositions),
+    load("GetPositions.mac"),
 
     Positions:GetPositions(Count,N),    Band:Positions[1],    Stack:Positions[2],    Row:Positions[3],    Column:Positions[4],    Temp: row(CombMatrix, (n*(Band-1)+Row)),
 
 
-    Temp: Temp[1],
+    Temp: args(Temp)[1],
 
 
     NotPossRow: rest(Temp,-(N-(n*(Stack-1))-Column+1)),
@@ -28,7 +28,7 @@ NotPossibles(Count,SudokuMatrix,CombMatrix,ListNotPossValues):=block([Band,Stack
     Temp: transpose(Temp),
 
 
-    Temp: Temp[1],
+    Temp: args(Temp)[1],
 
 
     NotPossCol: rest(Temp,-(N-(n*(Band-1))-Row+1)),
@@ -47,7 +47,7 @@ NotPossibles(Count,SudokuMatrix,CombMatrix,ListNotPossValues):=block([Band,Stack
     ),
 
 
-    TempRow: Temp[1],
+    TempRow: args(Temp)[1],
 
 
     NotPossBox: rest(TempRow, -(N-(n*(Row-1))-Column+1)),

--- a/PostCode/Permutations.mac
+++ b/PostCode/Permutations.mac
@@ -1,0 +1,133 @@
+/* Combined Permutations file */
+
+/* Swaps two bands of a CombMatrix */
+
+SwapBands(CombMatrix,Band1No,Band2No):=block([N:length(CombMatrix[1]),n:sqrt(N),TempBand:zeromatrix(n,N)],
+    for i:1 thru n do (
+        for j:1 thru N do (
+            TempBand[i,j]:CombMatrix[n*(Band1No-1)+i,j]
+        )
+    ),
+
+    for i:1 thru n do (
+        for j:1 thru N do (
+            CombMatrix[n*(Band1No-1)+i,j]:CombMatrix[n*(Band2No-1)+i,j]
+        )
+    ),
+
+
+    for i:1 thru n do (
+        for j:1 thru N do (
+            CombMatrix[n*(Band2No-1)+i,j]:TempBand[i,j]
+        )
+    )
+);
+
+/* Swaps two stacks of a CombMatrix */
+
+SwapStacks(CombMatrix,Stack1No,Stack2No):=block([N:length(CombMatrix[1]),n:sqrt(N),TempStack:zeromatrix(N,n)],
+    for i:1 thru N do (
+        for j:1 thru n do (
+            TempStack[i,j]:CombMatrix[i,n*(Stack1No-1)+j]
+        )
+    ),
+
+    for i:1 thru N do (
+        for j:1 thru n do (
+            CombMatrix[i,n*(Stack1No-1)+j]:CombMatrix[i,n*(Stack2No-1)+j]
+        )
+    ),
+
+
+    for i:1 thru N do (
+        for j:1 thru n do (
+            CombMatrix[i,n*(Stack2No-1)+j]:TempStack[i,j]
+        )
+    )
+);
+
+/* Swaps the two specified rows within the specified band of a CombMatrix */
+
+SwapRows(CombMatrix,BandNo,Row1No,Row2No):=block([N:length(CombMatrix[1]),n:sqrt(N),TempRow:zeromatrix(1,N)],
+    for i:1 thru N do (
+        TempRow[1,i]:CombMatrix[n*(BandNo-1)+Row1No,i]
+    ),
+    for i:1 thru N do (
+        CombMatrix[n*(BandNo-1)+Row1No,i]:CombMatrix[n*(BandNo-1)+Row2No,i]
+    ),
+    for i:1 thru N do (
+        CombMatrix[n*(BandNo-1)+Row2No,i]:TempRow[1,i]
+    )
+);
+
+/* Swaps the two specified columns within the specified stack of a CombMatrix */
+
+SwapColumns(CombMatrix,StackNo,Column1No,Column2No):=block([N:length(CombMatrix[1]),n:sqrt(N),TempColumn:zeromatrix(N,1)],
+    for i:1 thru N do (
+        TempColumn[i,1]:CombMatrix[i,n*(StackNo-1)+Column1No]
+    ),
+    for i:1 thru N do (
+        CombMatrix[i,n*(StackNo-1)+Column1No]:CombMatrix[i,n*(StackNo-1)+Column2No]
+    ),
+    for i:1 thru N do (
+        CombMatrix[i,n*(StackNo-1)+Column2No]:TempColumn[i,1]
+    )
+);
+
+/* Reflects a Combined Matrix in one of the four possible axes */
+
+Reflect(CombMatrix,Axis):=block([N:length(CombMatrix[1]),NewMatrix,TempCol,TempRow,TempMatrix,TempMatrix2],
+    if Axis=1 then (
+        NewMatrix:col(CombMatrix,N),
+        for i:2 thru N do (
+            TempCol:col(CombMatrix,(N+1-i)),
+            NewMatrix:addcol(NewMatrix,TempCol)
+        )
+    ),
+
+    if Axis=2 then (
+        NewMatrix:row(CombMatrix,N),
+        for i:2 thru N do (
+            TempRow:row(CombMatrix,(N+1-i)),
+            NewMatrix:addrow(NewMatrix,TempRow)
+        )
+    ),
+
+    if Axis=3 then (
+        NewMatrix:transpose(CombMatrix)
+    ),
+
+    if Axis=4 then (
+        TempMatrix:col(CombMatrix,N),
+        for i:2 thru N do (
+            TempCol:col(CombMatrix,(N+1-i)),
+            TempMatrix:addcol(TempMatrix,TempCol)
+        ),
+    
+        TempMatrix2:row(TempMatrix,N),
+        for i:2 thru N do (
+            TempRow:row(TempMatrix,(N+1-i)),
+            TempMatrix2:addrow(TempMatrix2,TempRow)
+        ),
+        NewMatrix:transpose(TempMatrix2)
+    ),
+
+    CombMatrix:NewMatrix
+);
+
+/* Rotates a CombMatrix by either one, two or three quarters */
+
+Rotate(CombMatrix,NoOfRots):=block([N:length(CombMatrix[1]),OldMatrix,NewMatrix,TempCol],
+    OldMatrix:copymatrix(CombMatrix),
+    for i:1 thru NoOfRots do (
+        if i>1 then (
+            OldMatrix:copymatrix(NewMatrix)
+        ),
+        NewMatrix:transpose(row(OldMatrix,N)),
+        for j:1 thru (N-1) do (
+            TempCol:transpose(row(OldMatrix,N-j)),
+            NewMatrix:addcol(NewMatrix,TempCol)
+        )
+    ),
+    CombMatrix:NewMatrix
+);

--- a/PostCode/RemoveAllRandomGivens.mac
+++ b/PostCode/RemoveAllRandomGivens.mac
@@ -1,5 +1,10 @@
 
-/* Removes random values until no more can be removed whilst preserving a unique solution  */RemoveAllRandomGivens(CombMatrix):=block([N:length(CombMatrix[1]),ListOfRemCells,CNFSolM],    load(LoadRemoving),
+
+/* Removes random values until no more can be removed whilst preserving a unique solution  */
+
+
+
+RemoveAllRandomGivens(CombMatrix):=block([N:length(CombMatrix[1]),ListOfRemCells,CNFSolM],    load(LoadRemoving),
     LoadRemoving(),
     SeedRandom(),    ListOfRemCells:GenListRemCells(CombMatrix),    CNFSolM:ConvertToCNF(CombMatrix,true),
 
@@ -7,4 +12,3 @@
         RemoveOneRandomGiven(CombMatrix,CNFSolM,ListOfRemCells)
     )
 );
-

--- a/PostCode/RemoveOneRandomGiven.mac
+++ b/PostCode/RemoveOneRandomGiven.mac
@@ -1,8 +1,16 @@
 
-/* Remove one value selected using the PRNG */
-
-RemoveOneRandomGiven(CombMatrix,CNFSolM,ListOfRemCells):=block([],
-    ListValuePos:1+random(length(ListOfRemCells)),    ValuePos:ListOfRemCells[ListValuePos][1],    ListOfRemCells:delete(ListOfRemCells[ListValuePos],ListOfRemCells),    RemovedValue:GetValue(CombMatrix,CombMatrix,ValuePos),    SetValue(CombMatrix,CombMatrix,ValuePos,0),
-
-    Satisfiable:TestSatisfiable(CombMatrix,CNFSolM),    if Satisfiable="s SATISFIABLE" then (        SetValue(CombMatrix,CombMatrix,ValuePos,RemovedValue)    ),    Satisfiable:"");
-
+ /* Remove one value selected using the PRNG */
+	
+	RemoveOneRandomGiven(CombMatrix,CNFSolM,ListOfRemCells):=block(
+	    [],
+	    ListValuePos:1+random(length(ListOfRemCells)),
+	    ValuePos:ListOfRemCells[ListValuePos][1],
+	    ListOfRemCells:delete(ListOfRemCells[ListValuePos],ListOfRemCells),
+	    RemovedValue:GetValue(CombMatrix,CombMatrix,ValuePos),
+	    SetValue(CombMatrix,CombMatrix,ValuePos,0),
+	    Satisfiable:TestSatisfiable(CombMatrix,CNFSolM),
+	    if Satisfiable="s SATISFIABLE" then (
+	        SetValue(CombMatrix,CombMatrix,ValuePos,RemovedValue)
+	    ),
+	    Satisfiable:""
+	)$

--- a/PostCode/SMSolutionP.mac
+++ b/PostCode/SMSolutionP.mac
@@ -1,27 +1,48 @@
 
-
-/* Tests whether a Sudoku Matrix is a solution */
-
-SMSolutionP(SudokuMatrix):=block([n:length(SudokuMatrix[1]),N:n^2,Result:true,BaseList,TranBaseList,TempList,CombMatrix],
-    BaseList:makelist(x,x,N),
-    TranBaseList:transpose(BaseList),
-    for i:1 thru n while Result do (
-        for j:1 thru n while Result do (
-            TempList:sort(list_matrix_entries(SudokuMatrix[i,j])),
-            if TempList#BaseList then Result:false
-        )
-    ),
-    if Result=false then return(false),
-    load(ConvertSMToCM),
-    CombMatrix:ConvertSMToCM(SudokuMatrix),
-    for i:1 thru N while Result do (
-        TempList:sort(row(CombMatrix,i)),
-        if TempList#BaseList then Result:false
-    ),
-    for i:1 thru N while Result do (
-        TempList:sort(column(CombMatrix,i)),
-        if TempList#TranBaseList then Result:false
+
+
+/* Tests whether a Sudoku Matrix is a solution */
+
+
+
+SMSolutionP(SudokuMatrix):=block([n:length(SudokuMatrix[1]),N:n^2,Result:true,BaseList,TranBaseList,TempList,CombMatrix],
+
+    BaseList:makelist(x,x,N),
+
+    TranBaseList:transpose(BaseList),
+
+    for i:1 thru n while Result do (
+
+        for j:1 thru n while Result do (
+
+            TempList:sort(list_matrix_entries(SudokuMatrix[i,j])),
+
+            if TempList#BaseList then Result:false
+
+        )
+
+    ),
+
+    if Result=false then return(false),
+
+    load(ConvertSMToCM),
+
+    CombMatrix:ConvertSMToCM(SudokuMatrix),
+
+    for i:1 thru N while Result do (
+
+        TempList:sort(row(CombMatrix,i)),
+
+        if TempList#BaseList then Result:false
+
+    ),
+
+    for i:1 thru N while Result do (
+
+        TempList:sort(column(CombMatrix,i)),
+
+        if TempList#TranBaseList then Result:false
+
     ),
     Result
 );
-

--- a/PostCode/SMSolutionP.mac
+++ b/PostCode/SMSolutionP.mac
@@ -25,7 +25,7 @@ SMSolutionP(SudokuMatrix):=block([n:length(SudokuMatrix[1]),N:n^2,Result:true,Ba
 
     if Result=false then return(false),
 
-    load(ConvertSMToCM),
+    load("ConvertSMToCM.mac"),
 
     CombMatrix:ConvertSMToCM(SudokuMatrix),
 

--- a/PostCode/SetValue.mac
+++ b/PostCode/SetValue.mac
@@ -1,22 +1,28 @@
 
-
+
+
 /* Assigns a value to a position in a matrix */
 
 SetValue(Matrix, Type, Count, Value):=block([Positions,Band,Stack,Row,Column,CMRow,CMColumn],
     load(GetPositions),
     if Type=SudokuMatrix then (
         Positions:GetPositions(Count,(length(Matrix[1]))^2),
-        Band:Positions[1],
-        Stack:Positions[2],
-        Row:Positions[3],
-        Column:Positions[4],
+        Band:Positions[1],
+
+        Stack:Positions[2],
+
+        Row:Positions[3],
+
+        Column:Positions[4],
+
         Matrix[Band,Stack][Row,Column]:Value
     ),
     if Type=CombMatrix then (
         Positions:GetPositions(Count,length(Matrix[1])),
-        CMRow:Positions[5],
-        CMColumn:Positions[6],
+        CMRow:Positions[5],
+
+        CMColumn:Positions[6],
+
         Matrix[CMRow,CMColumn]:Value
     )
 );
-

--- a/PostCode/SetValue.mac
+++ b/PostCode/SetValue.mac
@@ -4,7 +4,7 @@
 /* Assigns a value to a position in a matrix */
 
 SetValue(Matrix, Type, Count, Value):=block([Positions,Band,Stack,Row,Column,CMRow,CMColumn],
-    load(GetPositions),
+    load("GetPositions.mac"),
     if Type=SudokuMatrix then (
         Positions:GetPositions(Count,(length(Matrix[1]))^2),
         Band:Positions[1],

--- a/PostCode/SudokuMatrixP.mac
+++ b/PostCode/SudokuMatrixP.mac
@@ -1,23 +1,40 @@
 
-/* Tests whether an object is of the form of a Sudoku Matrix of the size specified */
-
-SudokuMatrixP(Object,Size):=block([N:Size,n:sqrt(Size),Result:true],
-    if matrixp(Object)=false then return(false),
-    if matrix_size(Object)#[n,n] then return(false),
-    for i:1 thru n while Result do (
-        for j:1 thru n while Result do (
-            if matrixp(Object[i,j])=false then Result:false
-            else if matrix_size(Object[i,j])#[n,n] then Return:false
-            else (
-                for k:1 thru n while Result do(
-                    for l:1 thru n while Result do block([Value:Object[i,j][k,l]],
-                        if not integerp(Value) then Result:false
-                        else if Value<0 or Value>N then Result:false
-                    )
-                )
-            )
-        )
+/* Tests whether an object is of the form of a Sudoku Matrix of the size specified */
+
+
+
+SudokuMatrixP(Object,Size):=block([N:Size,n:sqrt(Size),Result:true],
+
+    if matrixp(Object)=false then return(false),
+
+    if matrix_size(Object)#[n,n] then return(false),
+
+    for i:1 thru n while Result do (
+
+        for j:1 thru n while Result do (
+
+            if matrixp(Object[i,j])=false then Result:false
+
+            else if matrix_size(Object[i,j])#[n,n] then Return:false
+
+            else (
+
+                for k:1 thru n while Result do(
+
+                    for l:1 thru n while Result do block([Value:Object[i,j][k,l]],
+
+                        if not integerp(Value) then Result:false
+
+                        else if Value<0 or Value>N then Result:false
+
+                    )
+
+                )
+
+            )
+
+        )
+
     ),
     Result
 );
-

--- a/PostCode/TestSatisfiable.mac
+++ b/PostCode/TestSatisfiable.mac
@@ -1,5 +1,5 @@
 
-/* Tests whether a Combined Matrix has a satisfiable solution other then the one provided */TestSatisfiable(CombMatrix,CNFSolM):=block([N:length(CombMatrix[1]),Found:false,Stream],    load(ConvertToCNF),    load(stringproc),    CNFCombM:ConvertToCNF(CombMatrix,false),
+/* Tests whether a Combined Matrix has a satisfiable solution other then the one provided */TestSatisfiable(CombMatrix,CNFSolM):=block([N:length(CombMatrix[1]),Found:false,Stream],    load("ConvertToCNF.mac"),    load(stringproc),    CNFCombM:ConvertToCNF(CombMatrix,false),
     Answer:"",
     if N=4 then (
         system("C:/Users/James/Documents/GitHub/Maxima/Solver/CopyBase4x4Temp")

--- a/PostCode/TestSudoku.wxm
+++ b/PostCode/TestSudoku.wxm
@@ -1,0 +1,38 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 22.04.0 ] */
+/* [wxMaxima: input   start ] */
+file_search_maxima: append (file_search_maxima,["C:/Users/Usuario/Sudoku_Maxima", "C:/Users/Usuario/Sudoku_Maxima/PostCode"])$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+load("GenSolution.mac")$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+file_search_maxima;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+/* Generate a 9x9 Sudoku solution */
+GenSolution(9);
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+/* Display the combined matrix (flat Sudoku grid) */
+CombMatrix;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+/* Display the Sudoku matrix (block structure) */
+SudokuMatrix;
+/* [wxMaxima: input   end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 22.04.0"$

--- a/PreCode/TestPreCode.wxm
+++ b/PreCode/TestPreCode.wxm
@@ -1,0 +1,32 @@
+/* [wxMaxima batch file version 1] [ DO NOT EDIT BY HAND! ]*/
+/* [ Created with wxMaxima version 22.04.0 ] */
+/* [wxMaxima: input   start ] */
+file_search_maxima: append (file_search_maxima,["C:/Users/Usuario/Sudoku_Maxima", "C:/Users/Usuario/Sudoku_Maxima/PreCode"])$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+batch("RootSolutionN.wxm")$
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+file_search_maxima;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+/* Display the root solution combined matrix */
+LargeMComb;
+/* [wxMaxima: input   end   ] */
+
+
+/* [wxMaxima: input   start ] */
+/* Display the root solution block matrix */
+LargeM;
+/* [wxMaxima: input   end   ] */
+
+
+
+/* Old versions of Maxima abort on loading files that end in a comment. */
+"Created with wxMaxima 22.04.0"$

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sudoku implementation in Maxima.
 
-This code was initally left in GitHub by the user Cheesily.
+This code was initally left in GitHub by the user Cheesily since 2014.
 
 Can be corrected and expanded to make it fully operative.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Sudoku implementation in Maxima.
+
+This code was initally left in GitHub by the user Cheesily.
+
+Can be corrected and expanded to make it fully operative.


### PR DESCRIPTION
Title: Add Sudoku Killer Functions
Description:
This pull request introduces SudokuKillerFunctions.wxm, a new Maxima batch file containing a comprehensive set of functions specifically designed for Killer Sudoku puzzle operations.

Key Features Added:
check_killer(upto, boxes): Generates valid integer partitions for Killer Sudoku cages, ensuring no zeros and unique digits under 10.
check_many(list): Evaluates multiple cage configurations and finds valid combinations where the total sum matches the expected cardinality.
including(list, set) and excluding(list, set): Filter cage possibilities based on whether they must include or exclude specific digit sets.
complement(list): Computes complementary digit sets for each cage configuration.
filtered_by_complement() and filtered_other_way(): Advanced filtering functions for cage possibilities based on complementary sets.
common(list): Identifies digits that appear in all possible configurations for a given position.
Purpose:
These functions extend the Sudoku_Maxima project to support Killer Sudoku (also known as Sum Sudoku) puzzles, where cells within cages must sum to specific values. The implementation provides tools for generating, validating, and solving Killer Sudoku constraints within the Maxima computer algebra system.

Files Changed:
Added: SudokuKillerFunctions.wxm - New file with Killer Sudoku utility functions
Testing:
The functions are designed to work with the existing Sudoku_Maxima framework and can be loaded alongside other Maxima batch files for generating and solving Killer Sudoku puzzles.

This addition enhances the project's capabilities for advanced Sudoku variants while maintaining compatibility with the existing codebase.